### PR TITLE
Updated readyup.sp with sm_caster usage statement

### DIFF
--- a/readyup.sp
+++ b/readyup.sp
@@ -170,6 +170,12 @@ stock bool:IsIDCaster(const String:AuthID[])
 
 public Action:Caster_Cmd(client, args)
 {
+	if(args < 1)
+	{
+		PrintToChat(client, "[SM] Usage: sm_caster <player>");
+		return Plugin_Handled;
+	}
+	
 	decl String:buffer[64];
 	GetCmdArg(1, buffer, sizeof(buffer));
 

--- a/readyup.sp
+++ b/readyup.sp
@@ -172,7 +172,7 @@ public Action:Caster_Cmd(client, args)
 {
 	if(args < 1)
 	{
-		PrintToChat(client, "[SM] Usage: sm_caster <player>");
+		ReplyToCommand(client, "[SM] Usage: sm_caster <player>");
 		return Plugin_Handled;
 	}
 	


### PR DESCRIPTION
Updated readyup.sp so that the sm_caster command will print a usage statement if it is called without an argument.
